### PR TITLE
Refactor text comparison to maintain original case in forwarded text

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -53,9 +53,9 @@ except Exception as ap:
 async def sender_bH(event):
     for i in TO:
         try:
-            message_text = event.raw_text.lower()
+            message_text = event.raw
 
-            if any(blocked_text in message_text for blocked_text in BLOCKED_TEXTS):
+            if any(blocked_text.lower() in message_text.lower() for blocked_text in BLOCKED_TEXTS):
                 print(f"Blocked message containing one of the specified texts: {event.raw_text}")
                 logging.warning(f"Blocked message containing one of the specified texts: {event.raw_text}")
                 continue

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,6 @@ from telethon import TelegramClient, events
 from decouple import config
 import logging
 from telethon.sessions import StringSession
-import os
 
 # Configure logging
 logging.basicConfig(format='[%(levelname) 5s/%(asctime)s] %(name)s: %(message)s', level=logging.WARNING)


### PR DESCRIPTION
Changed the text processing logic from converting the entire message to lowercase
` message_text = event.raw.lower()`
`
            if any(blocked_text in message_text for blocked_text in BLOCKED_TEXTS):`

to converting only the message_text to lowercase
` message_text = event.raw`
`
            if any(blocked_text.lower() in message_text.lower() for blocked_text in BLOCKED_TEXTS): `

This ensures that the original case of the texts, as passed in _event_, is maintained while forwarding and only changed for the purpose of comparsion with _blocked_text_.